### PR TITLE
fix: Get module name from argument when absent in modinfo

### DIFF
--- a/mfd_package_manager/linux.py
+++ b/mfd_package_manager/linux.py
@@ -158,7 +158,7 @@ class LinuxPackageManager(UnixPackageManager):
         name_regex = r"^\s*name:\s+(?P<name>.*)"
         version_match = re.search(version_regex, result.stdout, flags=re.MULTILINE)
         name_match = re.search(name_regex, result.stdout, flags=re.MULTILINE)
-        name = name_match.group("name") if name_match is not None else "N/A"
+        name = name_match.group("name") if name_match is not None else driver_name
         version = version_match.group("version") if version_match is not None else "N/A"
         return DriverInfo(driver_version=version, driver_name=name)
 

--- a/tests/unit/test_mfd_package_manager/test_linux.py
+++ b/tests/unit/test_mfd_package_manager/test_linux.py
@@ -163,7 +163,7 @@ class TestLinuxPackageManager:
         manager._connection.execute_command.return_value = ConnectionCompletedProcess(
             args="", stdout=output, return_code=0
         )
-        assert manager.get_driver_info("i40e") == DriverInfo(driver_name="N/A", driver_version="N/A")
+        assert manager.get_driver_info("i40e") == DriverInfo(driver_name="i40e", driver_version="N/A")
 
     def test_insert_module(self, manager):
         manager.insert_module("i40e", "-a")


### PR DESCRIPTION
This pull request updates the behavior for retrieving driver information when the driver's name cannot be found in the output. Instead of defaulting to "N/A", the code now falls back to using the provided `driver_name` argument. The related unit test is also updated to reflect this new behavior.

Driver info fallback logic:

* In `mfd_package_manager/linux.py`, the fallback value for `driver_name` in `get_driver_info` is changed from "N/A" to the provided `driver_name` argument.

Test updates:

* In `tests/unit/test_mfd_package_manager/test_linux.py`, the assertion in `test_get_driver_info_no_info` is updated to expect the fallback to the provided driver name instead of "N/A".