### PR TITLE
feat: Add RDMA install method for Windows and Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Constructor:
 * `is_package_installed_via_rpm(self, package: str, cwd: "Path | str | None" = None) -> bool` - verify if package installed using rpm
 * `is_package_installed_via_dpkg(self, package: str, cwd: "Path | str | None" = None) -> bool`- verify if package installed using dpkg
 * `install_package_via_dnf(self, package: str, cwd: "Path | str | None" = None) -> "ConnectionCompletedProcess":` - install package using dnf
+* `install_rdma_drivers(self, build_path: "Path | str") -> None:` - install RDMA drivers from build path.
 
 #### ESXiPackageManager:
 * `get_driver_info(self, interface_name: str) -> DriverInfo` - Get driver info (name, version).
@@ -143,6 +144,7 @@ Constructor:
 * `_get_inf_device_section_name(self, build: str, section_dictionary: Dict[str, List[str]], component_id: str, client_os: bool) -> str` get the section name from the parsed section dictionary corresponding to the specified component id
 * `_get_server_or_client_section(self, section_dictionary: Dict[str, List[str]], client_os: bool) -> List[str]` get all the component ids from the parsed section dictionary for either the server or client OS section
 * `_get_default_vals_from_inf(self, device_section_name: str, section_dictionary: Dict[str, List[str]]) -> List[Tuple[str, str]]` get all advanced feature names and the default value for each feature   
+* `install_rdma_drivers(self, build_path: "Path | str") -> None:` - install RDMA drivers from build path.
 
 #### BSDPackageManager:
 * API from Unix Package Manager

--- a/examples/linux_example.py
+++ b/examples/linux_example.py
@@ -51,3 +51,6 @@ package_manager.pip_install_packages(
 package_manager.is_package_installed_via_rpm(package="make", cwd="/home/user")
 package_manager.is_package_installed_via_dpkg(package="docker")
 package_manager.install_package_via_dnf("1.2.3", cwd="/home")
+
+# install rdma drivers from build path
+package_manager.install_rdma_drivers("/home/rdma_drivers/build")

--- a/examples/windows_example.py
+++ b/examples/windows_example.py
@@ -31,3 +31,6 @@ device_id = DeviceID(0x1572)
 
 package_manager.install_build(r"C:\Users\admin\Downloads\drivers", device_id)
 package_manager.install_build(r"C:\Users\admin\Downloads\drivers")  # will install on all devices
+
+# install rdma drivers from build path
+package_manager.install_rdma_drivers(r"C:\Users\admin\Downloads\drivers")

--- a/mfd_package_manager/base.py
+++ b/mfd_package_manager/base.py
@@ -327,3 +327,11 @@ class PackageManager(ABC):
                 level=log_levels.MODULE_DEBUG,
                 msg="Connection interpreter is not available for other connection than Python (RPyC and Local)",
             )
+
+    def install_rdma_drivers(self) -> None:
+        """
+        Install RDMA drivers if not installed.
+
+        :raises PackageManagerModuleException: on failure
+        """
+        raise NotImplementedError("Method install_rdma_drivers is not implemented for base PackageManager class.")

--- a/tests/unit/test_mfd_package_manager/test_base.py
+++ b/tests/unit/test_mfd_package_manager/test_base.py
@@ -139,7 +139,8 @@ class TestMfdPackageManager:
         conn2 = mocker.create_autospec(RPyCConnection)
         conn2.get_os_name.return_value = OSName.ESXI
         with pytest.raises(
-            PackageManagerConnectedOSNotSupported, match="Not supported OS for controller PackageManager: [OSName.ESXI|VMKernel]"
+            PackageManagerConnectedOSNotSupported,
+            match="Not supported OS for controller PackageManager: [OSName.ESXI|VMKernel]",
         ):
             PackageManager(connection=conn, controller_connection=conn2)
 


### PR DESCRIPTION
This pull request adds support for installing RDMA drivers on both Linux and Windows platforms via a new `install_rdma_drivers` method in the respective package manager classes. The implementation includes robust error handling, platform-specific logic for locating and installing the drivers, and comprehensive unit tests to verify correct behavior and edge cases. Documentation and usage examples have also been updated to reflect the new functionality.

### RDMA Driver Installation Feature

* Added `install_rdma_drivers(self, build_path: "Path | str") -> None` method to both `LinuxPackageManager` and `WindowsPackageManager`, enabling automated installation of RDMA drivers from a specified build path. This includes extracting driver files, running installation scripts on Linux, and copying/installing INF files and certificates on Windows. [[1]](diffhunk://#diff-d240177940dfcfe18b9c5755943a6ae987f89bea5d786d770f7a2e136d0a8549R744-R793) [[2]](diffhunk://#diff-d47fa401867234f56dd13af42a9b1e782f66afde414ef66af666bbc8142c0148R926-R969)
* Implemented platform-specific logic for locating the correct driver build directories and handling Windows OS version matching with a new mapping and helper method `_get_rdma_folder_for_os_version`. [[1]](diffhunk://#diff-d47fa401867234f56dd13af42a9b1e782f66afde414ef66af666bbc8142c0148R58-R65) [[2]](diffhunk://#diff-d47fa401867234f56dd13af42a9b1e782f66afde414ef66af666bbc8142c0148R553-R565)

### Documentation and Usage Examples

* Updated `README.md` to document the new `install_rdma_drivers` method for both Linux and Windows package managers. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R114) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R147)
* Added usage examples for the new method in `examples/linux_example.py` and `examples/windows_example.py`. [[1]](diffhunk://#diff-e5c897f8c8e2376f2e0099845fcbd556c046463b59c9e6682c8c760d04339c49R54-R56) [[2]](diffhunk://#diff-bcb36087c74cc182cd57aa81755fa9b43d2493d0bc3c0f8e7f085cca35995d07R34-R36)

### Unit Testing and Error Handling

* Added comprehensive unit tests for RDMA driver installation, covering successful installation, missing build path, missing tar files, multiple tar files, command execution, and error scenarios for both Linux and Windows. [[1]](diffhunk://#diff-f2eabed3362aedcd490e351f2aec07e5bedf69b5bd84af15711bd5220f233de9R711-R833) [[2]](diffhunk://#diff-3c404d529967a4bf06d4d43ec42ef0b11b70dd1222f5f6c71e81c873b3bc0d92R1109-R1203)
* Improved error handling in the RDMA installation flow, raising descriptive exceptions for missing files, directories, or installation failures. [[1]](diffhunk://#diff-d240177940dfcfe18b9c5755943a6ae987f89bea5d786d770f7a2e136d0a8549R744-R793) [[2]](diffhunk://#diff-d47fa401867234f56dd13af42a9b1e782f66afde414ef66af666bbc8142c0148R926-R969)

### Base Class and Extensibility

* Added a stub `install_rdma_drivers` method to the base `PackageManager` class, raising `NotImplementedError`, to ensure extensibility and clear API boundaries for platform-specific implementations.